### PR TITLE
removed unnecessary platform-dependent build cache removal

### DIFF
--- a/extraParams.hxml
+++ b/extraParams.hxml
@@ -4,8 +4,4 @@
 
 -D warn
 
---java mc_api_temp/HxMcPlugin
-
-#--cmd mkdir bin
---cmd move /y "mc_api_temp\HxMcPlugin\HxMcPlugin.jar" "HxMcPlugin.jar"
---cmd rmdir /s /q "mc_api_temp"
+--java bin/HxMcPlugin


### PR DESCRIPTION
Currently this library uses `--cmd` flag to remove cache after compilation using windows commands, therefore `sh` throws unknown command error message each time after it is invoked by haxe compiler.

This library should leave the decision and implementation of cache removal to the end user because it locks this library down to windows developers only and because cache removal after each build is generally not a very good idea.